### PR TITLE
Added Ino64 Support for SVN for Freebsd12+

### DIFF
--- a/svnkit/src/main/java/org/tmatesoft/svn/core/internal/util/jna/SVNLinuxUtil.java
+++ b/svnkit/src/main/java/org/tmatesoft/svn/core/internal/util/jna/SVNLinuxUtil.java
@@ -458,7 +458,7 @@ public class SVNLinuxUtil {
             return 32;
         }
         if (SVNFileUtil.isBSD && SVNFileUtil.isIno64) {
-+            return 48;
+            return 48;
         }
         if (SVNFileUtil.isSolaris) {
             //64bit

--- a/svnkit/src/main/java/org/tmatesoft/svn/core/internal/util/jna/SVNLinuxUtil.java
+++ b/svnkit/src/main/java/org/tmatesoft/svn/core/internal/util/jna/SVNLinuxUtil.java
@@ -412,8 +412,11 @@ public class SVNLinuxUtil {
         if (SVNFileUtil.isSolaris && SVNFileUtil.is32Bit) {
             return 20;
         }
-        if (SVNFileUtil.isBSD) {
+        if (SVNFileUtil.isBSD && !SVNFileUtil.isIno64) {
             return 8;
+        }
+        if (SVNFileUtil.isBSD && SVNFileUtil.isIno64) {
+            return 24;
         }
         return 16;
     }
@@ -444,14 +447,18 @@ public class SVNLinuxUtil {
     }
 
     private static int getFileLastModifiedOffset() {
+        int groupOffset = getFileGroupIDOffset();
         if (SVNFileUtil.isLinux && SVNFileUtil.is64Bit) {
             return 88;
         }
         if (SVNFileUtil.isLinux && SVNFileUtil.is32Bit) {
             return 64;
         }
-        if (SVNFileUtil.isBSD) {
+        if (SVNFileUtil.isBSD && !SVNFileUtil.isIno64) {
             return 32;
+        }
+        if (SVNFileUtil.isBSD && SVNFileUtil.isIno64) {
++            return 48;
         }
         if (SVNFileUtil.isSolaris) {
             //64bit

--- a/svnkit/src/main/java/org/tmatesoft/svn/core/internal/wc/SVNFileUtil.java
+++ b/svnkit/src/main/java/org/tmatesoft/svn/core/internal/wc/SVNFileUtil.java
@@ -56,6 +56,8 @@ public class SVNFileUtil {
     public static final boolean isOS2;
     public static final boolean isOSX;
     public static final boolean isBSD;
+    /* FreeBSD project has changed STAT structure in release 12.0 */
+    public static final boolean isIno64;
     public static boolean isLinux;
     public static final boolean isSolaris;
     public static final boolean isOpenVMS;
@@ -137,6 +139,8 @@ public class SVNFileUtil {
 
         is32Bit = "32".equals(System.getProperty("sun.arch.data.model", "32"));
         is64Bit = "64".equals(System.getProperty("sun.arch.data.model", "64"));
+        
+        isIno64 = (isBSD && "freebsd".equals(osNameLC) && (12 <= Double.parseDouble(System.getProperty("os.version").split('-')[0]) ) );
 
         if (isOpenVMS) {
             setAdminDirectoryName("_svn");


### PR DESCRIPTION
**Problem**
FreeBSD 12+ has moved to ino64 (in 2017), plugin subversion (svnkit/nla) uses 32 offset that is incorrect for new systems. As a result, FreeBSD 12+ with Jenkins that makes svn pulls for builds fails or provides wrong data inside a package.  This happens when Jenkins tries to check out a code on a remote node.

**Links**
https://lists.freebsd.org/pipermail/freebsd-fs/2017-April/024684.html
https://www.tcm.phy.cam.ac.uk/sw/inodes64.htm 
http://freebsd.1045724.x6.nabble.com/Some-weird-errors-in-Jenkins-on-post-ino64-CURRENT-td6195425.html
https://issues.tmatesoft.com/issue/SVNKIT-740 

**Solution** 
Based on the knowledge above two files were updated. Freebsd version comparison was changed.
